### PR TITLE
Update lettuce-core, r2dbc-mysql, r2dbc-mssql to latest

### DIFF
--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    compile "io.lettuce:lettuce-core:5.1.1.RELEASE"
+    compile "io.lettuce:lettuce-core:6.0.0.RC2"
 
     testCompile "junit:junit:4.12"
     testCompile project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    compile "io.lettuce:lettuce-core:5.1.1.RELEASE"
+    compile "io.lettuce:lettuce-core:6.0.0.RC2"
 
     testCompile "org.junit.jupiter:junit-jupiter-api:5.4.2"
     testCompile "org.junit.jupiter:junit-jupiter-params:5.4.2"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compile "io.lettuce:lettuce-core:5.2.0.RELEASE"
+    compile "io.lettuce:lettuce-core:6.0.0.RC2"
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.5'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testCompile 'com.microsoft.sqlserver:mssql-jdbc:8.4.1.jre8'
 
     testCompile project(':r2dbc')
-    testCompile 'io.r2dbc:r2dbc-mssql:0.8.3.RELEASE'
+    testCompile 'io.r2dbc:r2dbc-mssql:0.8.4.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testCompile testFixtures(project(':r2dbc'))

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testCompile 'mysql:mysql-connector-java:8.0.21'
 
     testCompile testFixtures(project(':r2dbc'))
-    testCompile 'dev.miku:r2dbc-mysql:0.8.1.RELEASE'
+    testCompile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     compileOnly 'org.jetbrains:annotations:20.1.0'
 }


### PR DESCRIPTION
- Bump lettuce-core from "5.1.1.RELEASE" to "6.0.0.RC2"
- Bump r2dbc-mysql from "0.8.1.RELEASE" to "0.8.2.RELEASE"
- Bump r2dbc-mssql from "0.8.3.RELEASE" to "0.8.4.RELEASE"

Their latest version are using latest Netty which includes both security fixes and AArch64 performance improvements. Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/07/09/4-1-51-Final.html
  - https://netty.io/news/2020/09/08/4-1-52-Final.html